### PR TITLE
refactor: extend IgaBase.collect!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CartesianProducts"
 uuid = "ddfd9c64-15e7-45fc-8e16-950f3835cae5"
 authors = ["René Hiemstra <rrhiemstar@gmail.com>", "Michał Mika <michal@mika.sh>"]
-version = "0.15.0"
+version = "0.15.1"
 
 [deps]
 IgaBase = "9c103fa8-ae55-49f5-92db-ab77803cf2c4"

--- a/src/cartesian_product.jl
+++ b/src/cartesian_product.jl
@@ -1,4 +1,4 @@
-export ⨱, CartesianProduct, collect!, dimension, dropdims
+export ⨱, CartesianProduct, dropdims
 
 struct CartesianProduct{Dim,T,S<:Tuple} <: AbstractArray{T,Dim}
     data::S
@@ -76,7 +76,7 @@ function Base.collect(X::CartesianProduct)
     return A
 end
 
-@generated function collect!(X::CartesianProduct{Dim,T}, A::AbstractArray{T,Dim}) where {T,Dim}
+@generated function IgaBase.collect!(X::CartesianProduct{Dim,T}, A::AbstractArray{T,Dim}) where {T,Dim}
     quote
         @assert length(X)==length(A)
         @nloops $Dim i A begin
@@ -85,7 +85,7 @@ end
     end
 end
 
-@generated function collect!(X::CartesianProduct{Dim}, A::NTuple{Dim,<:AbstractArray}) where {Dim}
+@generated function IgaBase.collect!(X::CartesianProduct{Dim}, A::NTuple{Dim,<:AbstractArray}) where {Dim}
     quote
         @nexprs $Dim j->(A_j = A[j])
         @nexprs $Dim j->(size(A_j)==size(X))


### PR DESCRIPTION
`CartesianProducts.jl` and `IgaBase.jl` export collect!... This fixes the ambiguity when used simultaneously. 